### PR TITLE
 C-style pointer casting

### DIFF
--- a/src/xgui/debuga/debuger.cpp
+++ b/src/xgui/debuga/debuger.cpp
@@ -1310,11 +1310,12 @@ void DebugWin::chLayout() {
 	}
 }
 
-void DebugWin::regClick(QMouseEvent* ev) {
-	xLabel* lab = (xLabel*)sender();
+void DebugWin::regClick(QMouseEvent* ev) {	  
+	xLabel* lab = qobject_cast<xLabel*>(sender());
+	if ( lab == NULL ) return;	
 	int id = lab->id;
-	if (id < 0) return;
-	if (id > 15) return;
+	// Checking id is in range [0..15]
+	if ( !( (id-15)*(id-0) <= 0) ) return;
 	CPU* cpu = comp->cpu;
 	xRegBunch bunch = cpuGetRegs(cpu);
 	xRegister reg = bunch.regs[id];


### PR DESCRIPTION
Because xLabel defined as `class xLabel : public QLabel`
https://github.com/samstyle/Xpeccy/blob/88f789e3c9cc3cc666d44d4216bf7a575ee8462b/src/xgui/xgui.h#L53
IMHO need use true QT way :)