### PR TITLE
Perormance  [clang-analyzer-optin.performance.Padding]

### DIFF
--- a/src/filer.cpp
+++ b/src/filer.cpp
@@ -22,11 +22,11 @@ typedef struct {
 } xFileTypeInfo;
 
 typedef struct {
-	int id;
 	const char* defext;
-	int drv;
 	const char* name;
 	xFileTypeInfo* fti;
+	int id;
+	int drv;
 	int child[32];
 } xFileGroupInfo;
 


### PR DESCRIPTION
warning: Excessive padding in 'xFileGroupInfo' (8 padding bytes, where 0 is optimal).