### PR TITLE
Kempston Mouse sensitivity support

### DIFF
--- a/src/libxpeccy/hardware/common.c
+++ b/src/libxpeccy/hardware/common.c
@@ -245,12 +245,12 @@ int xInFADF(Computer* comp, int port) {
 
 int xInFBDF(Computer* comp, int port) {
 	comp->mouse->used = 1;
-	return comp->mouse->enable ? comp->mouse->xpos : 0xff;
+	return comp->mouse->enable ? comp->mouse->xpos * comp->mouse->sensitivity : 0xff;
 }
 
 int xInFFDF(Computer* comp, int port) {
 	comp->mouse->used = 1;
-	return comp->mouse->enable ? comp->mouse->ypos : 0xff;
+	return comp->mouse->enable ? comp->mouse->ypos * comp->mouse->sensitivity : 0xff;
 }
 
 // out

--- a/src/libxpeccy/input.c
+++ b/src/libxpeccy/input.c
@@ -374,6 +374,7 @@ unsigned char joyInput(Joystick* joy) {
 Mouse* mouseCreate(cbirq cb, void* p) {
 	Mouse* mou = (Mouse*)malloc(sizeof(Mouse));
 	memset(mou,0x00,sizeof(Mouse));
+	mou->sensitivity = 1.0f;
 	mou->xirq = cb;
 	mou->xptr = p;
 	return mou;

--- a/src/libxpeccy/input.h
+++ b/src/libxpeccy/input.h
@@ -105,6 +105,7 @@ typedef struct {
 	unsigned hasWheel:1;
 	unsigned swapButtons:1;
 	unsigned intrq:1;
+	double sensitivity;
 
 	unsigned lmb:1;
 	unsigned rmb:1;

--- a/src/xcore/profiles.cpp
+++ b/src/xcore/profiles.cpp
@@ -460,6 +460,7 @@ int prf_load_conf(xProfile* prf, std::string cfname, int flag) {
 					if (pnam == "mouse") comp->mouse->enable = arg.b;
 					if (pnam == "mouse.wheel") comp->mouse->hasWheel = arg.b;
 					if (pnam == "mouse.swapButtons") comp->mouse->swapButtons = arg.b;
+					if (pnam == "mouse.sensitivity") comp->mouse->sensitivity = arg.d;
 					if (pnam == "joy.extbuttons") comp->joy->extbuttons = arg.b;
 					if (pnam == "kbd.scantab") comp->keyb->pcmode = arg.i;
 					if (pnam == "keymap") {
@@ -655,6 +656,7 @@ int prfSave(std::string nm) {
 	fprintf(file, "mouse = %s\n", YESNO(comp->mouse->enable));
 	fprintf(file, "mouse.wheel = %s\n", YESNO(comp->mouse->hasWheel));
 	fprintf(file, "mouse.swapButtons = %s\n", YESNO(comp->mouse->swapButtons));
+	fprintf(file, "mouse.sensitivity = %f\n", comp->mouse->sensitivity);
 	fprintf(file, "joy.extbuttons = %s\n", YESNO(comp->joy->extbuttons));
 	fprintf(file, "gamepad.map = %s\n", prf->jmapName.c_str());
 	fprintf(file, "kbd.scantab = %i\n", comp->keyb->pcmode);

--- a/src/xgui/options/setupwin.cpp
+++ b/src/xgui/options/setupwin.cpp
@@ -484,6 +484,7 @@ void SetupWin::start() {
 	ui.ratEnable->setChecked(comp->mouse->enable);
 	ui.ratWheel->setChecked(comp->mouse->hasWheel);
 	ui.cbSwapButtons->setChecked(comp->mouse->swapButtons);
+	ui.sldSensitivity->setValue(comp->mouse->sensitivity * 1000.0f);
 	ui.cbKbuttons->setChecked(comp->joy->extbuttons);
 	ui.sldDeadZone->setValue(conf.joy.dead);
 	setPadName();
@@ -680,6 +681,7 @@ void SetupWin::apply() {
 	comp->mouse->enable = ui.ratEnable->isChecked() ? 1 : 0;
 	comp->mouse->hasWheel = ui.ratWheel->isChecked() ? 1 : 0;
 	comp->mouse->swapButtons = ui.cbSwapButtons->isChecked() ? 1 : 0;
+	comp->mouse->sensitivity = ui.sldSensitivity->value() * 0.001f;
 	comp->joy->extbuttons = ui.cbKbuttons->isChecked() ? 1 : 0;
 	conf.joy.dead = ui.sldDeadZone->value();
 	std::string kmname = getRFText(ui.keyMapBox);

--- a/ui/setupwin.ui
+++ b/ui/setupwin.ui
@@ -1650,6 +1650,44 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QLabel" name="label_66">
+                <property name="text">
+                 <string>Sensitivity:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="sldSensitivity">
+                <property name="minimum">
+                 <number>100</number>
+                </property>
+                <property name="maximum">
+                 <number>1000</number>
+                </property>
+                <property name="singleStep">
+                 <number>10</number>
+                </property>
+                <property name="pageStep">
+                 <number>100</number>
+                </property>
+                <property name="value">
+                 <number>1000</number>
+                </property>
+                <property name="sliderPosition">
+                 <number>1000</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>
@@ -3098,7 +3136,7 @@
                      <bool>false</bool>
                     </attribute>
                     <attribute name="verticalHeaderDefaultSectionSize">
-                     <number>17</number>
+                     <number>24</number>
                     </attribute>
                     <column/>
                     <column/>
@@ -3323,7 +3361,7 @@
                   <bool>false</bool>
                  </attribute>
                  <attribute name="verticalHeaderDefaultSectionSize">
-                  <number>17</number>
+                  <number>24</number>
                  </attribute>
                  <row/>
                  <column>
@@ -3797,7 +3835,7 @@
                 <bool>false</bool>
                </attribute>
                <attribute name="verticalHeaderDefaultSectionSize">
-                <number>17</number>
+                <number>24</number>
                </attribute>
               </widget>
              </item>


### PR DESCRIPTION
Due to the increased DPI of modern mice, I've found it useful to make mouse sensitivity configurable.

The sensitivity value can be adjusted in the UI (Options > Input > Kempston mouse > Sensitivity) or via profile configuration file:

```
[INPUT]
...
mouse.sensitivity = 1.000000
```

The scale ranges from 0.1 to 1.0 (with the default value of 1.0, which matches the original sensitivity in the emulator).