### PR TITLE
Display of the current values of some ports in the debugger's side widget

### DIFF
--- a/src/xgui/debuga/debuger.cpp
+++ b/src/xgui/debuga/debuger.cpp
@@ -74,6 +74,7 @@ void DebugWin::updateStyle() {
 	ui_misc.labHeadMem->setStyleSheet(str);
 	ui_misc.labHeadRay->setStyleSheet(str);
 	ui_misc.labHeadStack->setStyleSheet(str);
+	ui_misc.labHeadPorts->setStyleSheet(str);
 	ui_misc.labHeadSignal->setStyleSheet(str);
 	xDockWidget* dw;
 	void* ptr;
@@ -868,6 +869,7 @@ void DebugWin::fillNotCPU() {
 	if (memViewer->isVisible())
 		memViewer->fillImage();
 	fillStack();
+	fillPorts();
 }
 
 bool DebugWin::fillAll() {
@@ -1244,6 +1246,37 @@ void DebugWin::fillStack() {
 	ui_misc.labSP4->setText(str.mid(12,4));
 	ui_misc.labSP6->setText(str.mid(16,4));
 	ui_misc.labSP8->setText(str.mid(20,4));
+}
+
+// ports
+
+void DebugWin::fillPorts() {
+	Computer* comp = conf.prof.cur->zx;
+
+	// Current memory layout (0x7FFD)
+	ui_misc.labelPortValue7FFD->setText(QString("%1").arg(comp->p7FFD, 2, 16, QChar('0')).toUpper());
+
+	// Kempston Joystick
+	int v = comp->hw->in(comp, 0x1f);
+	ui_misc.labelPortValue1F->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+
+	// Keyboard state
+	v = comp->hw->in(comp, 0x7FFE);
+	ui_misc.labelPortValue7FFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xBFFE);
+	ui_misc.labelPortValueBFFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xDFFE);
+	ui_misc.labelPortValueDFFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xEFFE);
+	ui_misc.labelPortValueEFFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xF7FE);
+	ui_misc.labelPortValueF7FE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xFBFE);
+	ui_misc.labelPortValueFBFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xFDFE);
+	ui_misc.labelPortValueFDFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
+	v = comp->hw->in(comp, 0xFEFE);
+	ui_misc.labelPortValueFEFE->setText(QString("%1").arg(v, 2, 16, QChar('0')).toUpper());
 }
 
 // breakpoint

--- a/src/xgui/debuga/debuger.h
+++ b/src/xgui/debuga/debuger.h
@@ -142,6 +142,7 @@ class DebugWin : public QMainWindow {
 		void fillFlags(const char*);
 		void fillMem();
 		void fillStack();
+		void fillPorts();
 //		void fillFDC();
 //		void fillAY();
 //		void fillTape();

--- a/ui/dbgwidgets/form_misc.ui
+++ b/ui/dbgwidgets/form_misc.ui
@@ -175,6 +175,163 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="labHeadPorts">
+     <property name="text">
+      <string>PORTS</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayoutPorts">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelPortName1F">
+       <property name="text">
+        <string>  1F:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="labelPortValue1F">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelPortName7FFD">
+       <property name="text">
+        <string>7FFD:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="labelPortValue7FFD">
+       <property name="text">
+        <string>--</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeft</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelPortName7FFE">
+       <property name="text">
+        <string>7FFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="labelPortValue7FFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelPortNameBFFE">
+       <property name="text">
+        <string>BFFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="labelPortValueBFFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelPortNameDFFE">
+       <property name="text">
+        <string>DFFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="labelPortValueDFFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelPortNameEFFE">
+       <property name="text">
+        <string>EFFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="labelPortValueEFFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelPortNameF7FE">
+       <property name="text">
+        <string>F7FE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLabel" name="labelPortValueF7FE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelPortNameFBFE">
+       <property name="text">
+        <string>FBFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="labelPortValueFBFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelPortNameFDFE">
+       <property name="text">
+        <string>FDFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLabel" name="labelPortValueFDFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelPortNameFEFE">
+       <property name="text">
+        <string>FEFE:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLabel" name="labelPortValueFEFE">
+       <property name="text">
+        <string>--</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QLabel" name="labHeadSignal">
      <property name="text">
       <string>SIGNALS</string>


### PR DESCRIPTION
Added display of the current values of some ports in the debugger's side widget. The values are shown in **hexadecimal** format. This can be helpful during debugging, as it provides quick visibility into the real-time state of certain ports.

**Possible improvement**: It might be worth reconsidering the layout and moving this information to the `Watcher`. This would allow real-time monitoring of port states and help keep the side panel more organized.

