### PR TITLE
Fix win32 build issue

### DIFF
--- a/src/libxpeccy/defines.h
+++ b/src/libxpeccy/defines.h
@@ -8,7 +8,7 @@
 	#include <windows.h>
 	#define dlopen(d1,d2) LoadLibrary(d1)
 	#define dlclose FreeLibrary
-	#define dlsym GetProcAddress#else
+	#define dlsym GetProcAddress
 #else
 	#include <dlfcn.h>
 	#define EXPORTDLL


### PR DESCRIPTION
Fix for typo in macro definition for win32 build