### PR TITLE
Fix default Zoom slider value in ZXScrWidget

### DIFF
--- a/src/xgui/debuga/dbg_zxscr.cpp
+++ b/src/xgui/debuga/dbg_zxscr.cpp
@@ -17,6 +17,9 @@ xZXScrWidget::xZXScrWidget(QString i, QString t, QWidget* p):xDockWidget(i,t,p) 
 
 	connect(ui.sldScale, &QSlider::valueChanged, this, &xZXScrWidget::setZoom);
 
+	// setting initial values
+	ui.sldScale->setValue(conf.dbg.scrzoom);
+
 	hwList << HWG_ZX << HWG_ALF;
 }
 


### PR DESCRIPTION
Slider was always set to the minimum value in the UI after Xpeccy fresh start. This fix makes the widget initialization respect the value saved in configuration.