### PR TITLE
Fix for incorrect HAT state reading on some drivers

### DIFF
--- a/src/xcore/gamepad.cpp
+++ b/src/xcore/gamepad.cpp
@@ -469,7 +469,7 @@ void xGamepad::timerEvent(QTimerEvent* e) {
 		// buttons
 		int n = SDL_JoystickNumButtons(sjptr);
 		// clamp if HAT is present: skip virtual D-Pad buttons (>=12)
-		if (h > 0 && n > 11) n = 11;
+		if (h > 0 && n > 12) n = 12;
 		int state;
 		while (n > 0) {
 			n--;


### PR DESCRIPTION
Some drivers expose D-Pad both as a HAT and as 4 extra buttons (12-15).
Over Bluetooth these "virtual" buttons are always 0 and may overwrite real HAT state.
To avoid duplicate/invalid D-Pad events we clamp the button count whenever at least one HAT is present.

The issue appeared after switching from event-driven input (state changes only) to polling input (continuous state queries). With polling, the always-zero virtual buttons started to overwrite the HAT state.
