### PR TITLE
Improved handling of temporarily disconnected gamepads

### DIFF
--- a/src/xcore/config.cpp
+++ b/src/xcore/config.cpp
@@ -197,9 +197,9 @@ void saveConfig() {
 	fprintf(cfile, "fast = %s\n", YESNO(conf.tape.fast));
 
 	fprintf(cfile, "\n[INPUT]\n\n");
-	fprintf(cfile, "gamepad = %s\n", conf.joy.gpad->name().toLocal8Bit().data());
+	fprintf(cfile, "gamepad = %s\n", conf.joy.gpad->getStoredName().toLocal8Bit().data());
 	fprintf(cfile, "deadzone = %i\n", conf.joy.gpad->deadZone());
-	fprintf(cfile, "gamepad2 = %s\n", conf.joy.gpadb->name().toLocal8Bit().data());
+	fprintf(cfile, "gamepad2 = %s\n", conf.joy.gpadb->getStoredName().toLocal8Bit().data());
 	fprintf(cfile, "deadzone2 = %i\n", conf.joy.gpadb->deadZone());
 
 	fprintf(cfile, "\n[LEDS]\n\n");
@@ -399,8 +399,8 @@ void loadConfig() {
 				case SECT_INPUT:
 					if (pnam=="deadzone") conf.joy.gpad->setDeadZone(arg.i);
 					if (pnam=="deadzone2") conf.joy.gpadb->setDeadZone(arg.i);
-					if (pnam=="gamepad") conf.joy.gpad->open(arg.s); //conf.joy.curName = arg.s;
-					if (pnam=="gamepad2") conf.joy.gpadb->open(arg.s);
+					if (pnam=="gamepad") conf.joy.gpad->setStoredName(arg.s);
+					if (pnam=="gamepad2") conf.joy.gpad->setStoredName(arg.s);
 					break;
 				case SECT_VIDEO:
 					if (pnam=="layout") {

--- a/src/xcore/gamepad.h
+++ b/src/xcore/gamepad.h
@@ -67,6 +67,8 @@ class xGamepad : public QObject {
 		int getType();
 		void setDeadZone(int);
 		int deadZone();
+		void setStoredName(QString name);	// save the name of the selected gamepad
+		QString getStoredName();			// retrieve the stored gamepad name
 		QString name(int = -1);
 		QStringList getList();
 		static QString getButtonName(int);
@@ -91,6 +93,7 @@ class xGamepad : public QObject {
 		int stid;			// timer id (for sdl events)
 		int dead;
 		double deadf;
+		QString s_name;						// cached name of the selected gamepad
 		QList<xJoyMapEntry> map;			// gamepad map for gamepad
 		QMap<int, QMap<int, int> > jState;	// buttons/axis/hats state: -1 -> 1 | 1 -> -1 = release old one
 		union {


### PR DESCRIPTION
Enhanced support for wireless and Bluetooth gamepads that may temporarily disconnect or enter sleep mode.
Previously, configuration was lost after each disconnect, requiring the user to re-select the gamepad in settings.
Now, the stored configuration is preserved and automatically restored when the device reconnects.
The UI has been adjusted to prevent accidental overwriting of the selected gamepad while it’s disconnected.
