### PR TITLE
Fix random startup crash caused by uninitialized model counters

### DIFF
--- a/src/xgui/classes.cpp
+++ b/src/xgui/classes.cpp
@@ -294,7 +294,10 @@ QString xTreeBox::currentFile() {
 
 // base table model
 
-xTableModel::xTableModel(QObject* p):QAbstractTableModel(p) {}
+xTableModel::xTableModel(QObject* p):QAbstractTableModel(p) {
+	row_count = 0;
+	col_count = 0;
+}
 
 QModelIndex xTableModel::index(int row, int col, const QModelIndex& p) const {
 	return createIndex(row, col);


### PR DESCRIPTION
This PR initializes row_count and col_count in the xTableModel constructor.

Previously these fields were left uninitialized, which could lead to invalid row ranges
passed to beginInsertRows()/endInsertRows() and cause random crashes inside Qt
(e.g. in QHeaderView during startup).

The change removes undefined behavior and stabilizes application startup
without altering existing model logic.
