### PR TITLE
OpenGL Wayland Fix

### DIFF
--- a/src/emulwin.cpp
+++ b/src/emulwin.cpp
@@ -678,48 +678,41 @@ void MainWin::drawText(QPainter* pnt, int x, int y, const char* buf) {
 
 void MainWin::paintEvent(QPaintEvent*) {
 	QPainter pnt(this);
-#if defined(USEOPENGL)
-#if !BLOCKGL
-//	pnt.beginNativePainting();
-	makeCurrent();
-	if (prg.isLinked() && conf.vid.shd_support) {
-		prg.bind();
-		prg.setUniformValue("rubyInputSize",GLfloat(bytesPerLine/4.0), GLfloat(conf.prof.cur->zx->vid->vsze.y));
-		prg.setUniformValue("rubyOutputSize",GLfloat(width()), GLfloat(height()));
-		prg.setUniformValue("rubyTextureSize",GLfloat(bytesPerLine/4.0), GLfloat(conf.prof.cur->zx->vid->vsze.y));
-	}
-	glMatrixMode(GL_MODELVIEW);
-	glPushMatrix();
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-	glEnable(GL_TEXTURE_2D);
-	glLoadIdentity();
-	// draw texture
+#if defined(USEOPENGL) && !BLOCKGL
+	pnt.beginNativePainting();
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT);
+
 	if (!queue.isEmpty())
 		curtxid = queue.takeFirst();
-	glBindTexture(GL_TEXTURE_2D, curtxid);
-	glBegin(GL_TRIANGLE_STRIP);
-	glTexCoord2f(1.0, 0.0); glVertex2f(1.0, 0.0);	// RT
-	glTexCoord2f(0.0, 0.0); glVertex2f(0.0, 0.0);	// LT
-	glTexCoord2f(1.0, 1.0); glVertex2f(1.0, 1.0);	// RB
-	glTexCoord2f(0.0, 1.0); glVertex2f(0.0, 1.0);	// LB
-	glEnd();
-	if (prg.isLinked() && conf.vid.shd_support)
+
+	if (prg.isLinked()) {
+		const qreal r = widgetDpr(this);
+		Computer* comp = conf.prof.cur->zx;
+		const GLfloat tex_w = GLfloat(bytesPerLine / 4.0);
+		const GLfloat tex_h = GLfloat(comp->vid->vsze.y);
+		prg.bind();
+		prg.setUniformValue("u_tex", 0);
+		prg.setUniformValue("rubyInputSize",   tex_w, tex_h);
+		prg.setUniformValue("rubyTextureSize", tex_w, tex_h);
+		prg.setUniformValue("rubyOutputSize",  GLfloat(width() * r), GLfloat(height() * r));
+
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, curtxid);
+
+		vao.bind();
+		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+		vao.release();
+
 		prg.release();
-	glDisable(GL_TEXTURE_2D);
-	glMatrixMode(GL_MODELVIEW);
-	glPopMatrix();
+	}
 	glFlush();
-//	pnt.endNativePainting();
-//	QPainter pnt(this);
-	drawIcons(pnt);
-#endif
+	pnt.endNativePainting();
 #else
 	Computer* comp = conf.prof.cur->zx;
-//	QPainter pnt(this);
-	pnt.drawImage(0,0, QImage(comp->debug ? scrimg : bufimg, width(), height(), QImage::Format_RGBA8888));
-	drawIcons(pnt);
-//	pnt.end();
+	pnt.drawImage(0, 0, QImage(comp->debug ? scrimg : bufimg, width(), height(), QImage::Format_RGBA8888));
 #endif
+	drawIcons(pnt);
 	pnt.end();
 }
 

--- a/src/emulwin.cpp
+++ b/src/emulwin.cpp
@@ -1,3 +1,4 @@
+#include <QMatrix4x4>
 #include <QMenu>
 #include <QMessageBox>
 #include <QProgressBar>
@@ -691,8 +692,15 @@ void MainWin::paintEvent(QPaintEvent*) {
 		Computer* comp = conf.prof.cur->zx;
 		const GLfloat tex_w = GLfloat(bytesPerLine / 4.0);
 		const GLfloat tex_h = GLfloat(comp->vid->vsze.y);
+		static const QMatrix4x4 legacyMvp = []{
+			QMatrix4x4 m;
+			m.ortho(0.0f, 1.0f, 1.0f, 0.0f, -1.0f, 1.0f);
+			return m;
+		}();
 		prg.bind();
 		prg.setUniformValue("u_tex", 0);
+		prg.setUniformValue("rubyTexture", 0);
+		prg.setUniformValue("u_mvp_", legacyMvp);
 		prg.setUniformValue("rubyInputSize",   tex_w, tex_h);
 		prg.setUniformValue("rubyTextureSize", tex_w, tex_h);
 		prg.setUniformValue("rubyOutputSize",  GLfloat(width() * r), GLfloat(height() * r));

--- a/src/emulwin.h
+++ b/src/emulwin.h
@@ -27,6 +27,16 @@
 // for windows
 #define STICKY_KEY 1
 
+inline qreal widgetDpr(const QWidget* w) {
+#if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
+	return w->devicePixelRatioF();
+#elif QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+	return w->devicePixelRatio();
+#else
+	return 1.0;
+#endif
+}
+
 enum {
 	led_kbd = 0,
 	led_joy,
@@ -59,6 +69,8 @@ typedef struct {
 		class MainWin : public QGLWidget {
 	#else
 		#include <QOpenGLWidget>
+		#include <QOpenGLBuffer>
+		#include <QOpenGLVertexArrayObject>
 		class MainWin : public QOpenGLWidget, protected QOpenGLFunctions {
 	#endif
 #else
@@ -230,6 +242,8 @@ typedef struct {
 		QOpenGLShaderProgram prg;
 		QOpenGLShader* vtx_shd;
 		QOpenGLShader* frg_shd;
+		QOpenGLVertexArrayObject vao;
+		QOpenGLBuffer vbo;
 #endif
 #endif
 };

--- a/src/emw_opengl.cpp
+++ b/src/emw_opengl.cpp
@@ -2,21 +2,62 @@
 
 #if defined(USEOPENGL) && !BLOCKGL
 
+namespace {
+
+// Interleaved quad: position (x,y) + texcoord (u,v), triangle strip order
+// matching the legacy glBegin sequence (RT, LT, RB, LB). Positions are in
+// [0,1]² and the vertex shader maps them to NDC with Y flipped so that the
+// texture's top-left sample lands at the window's top-left.
+constexpr GLfloat kQuadVertices[] = {
+	1.0f, 0.0f,  1.0f, 0.0f,
+	0.0f, 0.0f,  0.0f, 0.0f,
+	1.0f, 1.0f,  1.0f, 1.0f,
+	0.0f, 1.0f,  0.0f, 1.0f,
+};
+
+bool currentContextIsGLES() {
+	QOpenGLContext* ctx = QOpenGLContext::currentContext();
+	return ctx && ctx->isOpenGLES();
+}
+
+constexpr const char* glslVersionPrefix(bool es) {
+	return es
+		? "#version 300 es\nprecision highp float;\n"
+		: "#version 330\n";
+}
+
+const char* defaultVertexShaderBody() {
+	return
+		"layout(location=0) in vec2 a_pos;\n"
+		"layout(location=1) in vec2 a_uv;\n"
+		"out vec2 v_uv;\n"
+		"void main() {\n"
+		"    v_uv = a_uv;\n"
+		"    gl_Position = vec4(a_pos.x * 2.0 - 1.0, 1.0 - a_pos.y * 2.0, 0.0, 1.0);\n"
+		"}\n";
+}
+
+const char* defaultFragmentShaderBody() {
+	return
+		"in vec2 v_uv;\n"
+		"out vec4 fragColor;\n"
+		"uniform sampler2D u_tex;\n"
+		"void main() {\n"
+		"    fragColor = texture(u_tex, v_uv);\n"
+		"}\n";
+}
+
+QString composeShader(const char* body) {
+	return QString::fromLatin1(glslVersionPrefix(currentContextIsGLES()))
+	     + QString::fromLatin1(body);
+}
+
+} // anonymous namespace
+
 void MainWin::initializeGL() {
 	qDebug() << __FUNCTION__;
 #if !ISLEGACYGL
 	initializeOpenGLFunctions();
-	QSurfaceFormat frmt;
-#if (QT_VERSION >= QT_VERSION_CHECK(5,5,0))
-	frmt.setSwapBehavior(QSurfaceFormat::SingleBuffer);	// since Qt5.5
-#endif
-	frmt.setSwapInterval(0);				// 0 - off. N>0 - each N vsyncs
-	frmt.setDepthBufferSize(24);
-	frmt.setStencilBufferSize(8);
-	frmt.setVersion(3,0);
-	frmt.setProfile(QSurfaceFormat::CoreProfile);
-	QSurfaceFormat::setDefaultFormat(frmt);
-	// setFormat(frmt);
 	conf.vid.shd_support = QOpenGLShader::hasOpenGLShaders(QOpenGLShader::Vertex) && QOpenGLShader::hasOpenGLShaders(QOpenGLShader::Fragment);
 	curtex = 0;
 	qDebug() << "vtx_shd";
@@ -37,29 +78,44 @@ void MainWin::initializeGL() {
 //	qDebug() << "frg_shd";
 //	frg_shd = new QGLShader(QGLShader::Fragment, cont);
 #endif
-	glGenTextures(4, texids);	// create texture
-	glEnable(GL_TEXTURE_2D);
+	glGenTextures(4, texids);
 	glEnable(GL_MULTISAMPLE);
 	for (int i = 0; i < 4; i++) {
-		// select texture
 		glBindTexture(GL_TEXTURE_2D, texids[i]);
-		// set filters for this texture
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	}
+
+#if !ISLEGACYGL
+	vao.create();
+	vao.bind();
+	vbo.create();
+	vbo.bind();
+	vbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+	vbo.allocate(kQuadVertices, sizeof(kQuadVertices));
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat),
+	                      reinterpret_cast<void *>(0));
+	glEnableVertexAttribArray(1);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat),
+	                      reinterpret_cast<void *>(2 * sizeof(GLfloat)));
+	vbo.release();
+	vao.release();
+#endif
+
 	loadShader();
 	if (!conf.vid.shd_support) qDebug() << "WARNING: Shaders not supported";
 	qDebug() << "end:" << __FUNCTION__;
 }
 
 void MainWin::resizeGL(int w, int h) {
-	glViewport(0, 0, w, h);
-	glMatrixMode(GL_PROJECTION);
-	glLoadIdentity();
-	glOrtho(0.0, 1.0, 1.0, 0.0, 1, 0);
-	glMatrixMode(GL_MODELVIEW);
+	const qreal r = widgetDpr(this);
+	const int vw = int(w * r + 0.5);
+	const int vh = int(h * r + 0.5);
+	glViewport(0, 0, vw, vh);
+	qDebug() << "resizeGL logical" << w << h << "dpr" << r << "viewport" << vw << vh;
 }
 
 void MainWin::paintGL() {
@@ -69,52 +125,65 @@ void MainWin::paintGL() {
 
 void MainWin::loadShader() {
 #if defined(USEOPENGL) && !BLOCKGL
-	QString path(std::string(conf.path.shdDir + SLASH + conf.vid.shader).c_str());
-	QFile file(path);
-	int mode = 0;
+	if (!conf.vid.shd_support) return;
+
 	QString vtx;
 	QString frg;
-	QString lin;
-	prg.removeAllShaders();
-	if (!conf.vid.shader.empty() && conf.vid.shd_support) {			// no shader selected
+	bool user_shader = false;
+
+	if (!conf.vid.shader.empty()) {
+		QString path(std::string(conf.path.shdDir + SLASH + conf.vid.shader).c_str());
+		QFile file(path);
 		if (file.open(QFile::ReadOnly)) {
-			while(!file.atEnd()) {
+			int mode = 0;
+			QString lin;
+			while (!file.atEnd()) {
 				lin = file.readLine().trimmed().append("\n");
 				if (lin.startsWith("vertex:")) {
 					mode = 1;
 				} else if (lin.startsWith("fragment:")) {
 					mode = 2;
 				} else {
-					switch(mode) {
+					switch (mode) {
 						case 1: vtx.append(lin); break;
 						case 2: frg.append(lin); break;
 					}
 				}
 			}
 			file.close();
-			if (!vtx.isEmpty()) {
-				if (!vtx_shd->compileSourceCode(vtx)) {
-					qDebug() << vtx_shd->log();
-				}
-			}
-			if (!frg.isEmpty()) {
-				if (!frg_shd->compileSourceCode(frg)) {
-					qDebug() << frg_shd->log();
-				}
-			}
-			if (vtx_shd->isCompiled() && frg_shd->isCompiled()) {
-				prg.addShader(vtx_shd);
-				prg.addShader(frg_shd);
-				prg.link();
-				setMessage(" Shader compiled ");
-			} else {
-				setMessage(" Shader compile error ");
-				conf.vid.shader.clear();
-				loadShader();
-			}
+			user_shader = true;
 		} else {
 			shitHappens("Can't open shader file");
 		}
+	}
+
+	if (!user_shader) {
+		vtx = composeShader(defaultVertexShaderBody());
+		frg = composeShader(defaultFragmentShaderBody());
+	}
+
+	prg.removeAllShaders();
+	const bool vtx_ok = vtx_shd->compileSourceCode(vtx);
+	if (!vtx_ok) qDebug() << "vertex shader:" << vtx_shd->log();
+	const bool frg_ok = frg_shd->compileSourceCode(frg);
+	if (!frg_ok) qDebug() << "fragment shader:" << frg_shd->log();
+
+	if (vtx_ok && frg_ok) {
+		prg.addShader(vtx_shd);
+		prg.addShader(frg_shd);
+		if (prg.link()) {
+			if (user_shader) setMessage(" Shader compiled ");
+			return;
+		}
+		qDebug() << "program link:" << prg.log();
+	}
+
+	if (user_shader) {
+		setMessage(" Shader compile error ");
+		conf.vid.shader.clear();
+		loadShader();
+	} else {
+		qDebug() << "FATAL: default shader failed to compile/link";
 	}
 #endif
 }

--- a/src/emw_opengl.cpp
+++ b/src/emw_opengl.cpp
@@ -1,5 +1,9 @@
 #include "emulwin.h"
 
+#include <QRegularExpression>
+#include <algorithm>
+#include <vector>
+
 #if defined(USEOPENGL) && !BLOCKGL
 
 namespace {
@@ -50,6 +54,120 @@ const char* defaultFragmentShaderBody() {
 QString composeShader(const char* body) {
 	return QString::fromLatin1(glslVersionPrefix(currentContextIsGLES()))
 	     + QString::fromLatin1(body);
+}
+
+// -----------------------------------------------------------------------------
+// Legacy GLSL 110 shim.
+//
+// Rewrites fixed-function-era shader source onto the core-compatible VBO
+// attribute and uniform layout. The transformation is entirely data-driven
+// by the tables below — to add a new legacy identifier, append a row to the
+// relevant table; to add a new preamble attribute or uniform, edit the stage
+// preamble helper. No change to loadShader or the shim pipeline is needed.
+// -----------------------------------------------------------------------------
+
+struct Rewrite {
+	QRegularExpression pattern;
+	QString replacement;
+};
+
+// Build a word-boundary-bounded regex for an identifier. Lookaround is used
+// instead of \b so tokens ending in punctuation (e.g. gl_TexCoord[0]) can
+// still be exact-matched as a future extension.
+QRegularExpression wordBoundedRegex(const char* identifier) {
+	return QRegularExpression(
+		QStringLiteral(R"((?<!\w))")
+		+ QRegularExpression::escape(QLatin1String(identifier))
+		+ QStringLiteral(R"((?!\w))"));
+}
+
+Rewrite rewrite(const char* identifier, const char* replacement) {
+	return { wordBoundedRegex(identifier), QString::fromLatin1(replacement) };
+}
+
+// Pure: apply a list of rewrites via left fold.
+QString applyRewrites(QString s, const std::vector<Rewrite>& rewrites) {
+	for (const auto& r : rewrites) s.replace(r.pattern, r.replacement);
+	return s;
+}
+
+// Signals whose presence in the source triggers the shim pipeline.
+// Absence of all of them lets a modern shader pass through untouched.
+const std::vector<QRegularExpression>& legacySignalPatterns() {
+	static const std::vector<QRegularExpression> r{
+		wordBoundedRegex("gl_Vertex"),
+		wordBoundedRegex("gl_MultiTexCoord0"),
+		wordBoundedRegex("gl_ModelViewProjectionMatrix"),
+		wordBoundedRegex("gl_FragColor"),
+		wordBoundedRegex("varying"),
+	};
+	return r;
+}
+
+bool sourceNeedsLegacyShim(const QString& src) {
+	const auto& patterns = legacySignalPatterns();
+	return std::any_of(patterns.begin(), patterns.end(),
+		[&src](const QRegularExpression& re) { return src.contains(re); });
+}
+
+// Pure: strip any existing `#version` directive so the shim can supply its own.
+QString stripVersionDirective(QString s) {
+	static const QRegularExpression re(
+		QStringLiteral(R"(^[ \t]*#[ \t]*version\b[^\n]*\n?)"),
+		QRegularExpression::MultilineOption);
+	s.replace(re, QString{});
+	return s;
+}
+
+// Rewrites applied to both vertex and fragment stages.
+const std::vector<Rewrite>& sharedRewrites() {
+	static const std::vector<Rewrite> r{
+		rewrite("texture2D", "texture"),
+	};
+	return r;
+}
+
+// Vertex-only rewrites.
+const std::vector<Rewrite>& vertexRewrites() {
+	static const std::vector<Rewrite> r{
+		rewrite("varying",                      "out"),
+		rewrite("gl_Vertex",                    "vec4(a_pos_.x, a_pos_.y, 0.0, 1.0)"),
+		rewrite("gl_MultiTexCoord0",            "vec4(a_uv_.x,  a_uv_.y,  0.0, 0.0)"),
+		rewrite("gl_ModelViewProjectionMatrix", "u_mvp_"),
+	};
+	return r;
+}
+
+// Fragment-only rewrites.
+const std::vector<Rewrite>& fragmentRewrites() {
+	static const std::vector<Rewrite> r{
+		rewrite("varying",      "in"),
+		rewrite("gl_FragColor", "frag_out_"),
+	};
+	return r;
+}
+
+QString vertexShimPreamble() {
+	return QString::fromLatin1(glslVersionPrefix(currentContextIsGLES()))
+	     + QStringLiteral(
+		     "layout(location=0) in vec2 a_pos_;\n"
+		     "layout(location=1) in vec2 a_uv_;\n"
+		     "uniform mat4 u_mvp_;\n");
+}
+
+QString fragmentShimPreamble() {
+	return QString::fromLatin1(glslVersionPrefix(currentContextIsGLES()))
+	     + QStringLiteral("out vec4 frag_out_;\n");
+}
+
+// Pipeline: strip version → shared rewrites → stage rewrites → prepend preamble.
+QString shimLegacyShader(QString src,
+                         const std::vector<Rewrite>& stageRewrites,
+                         const QString& preamble) {
+	src = stripVersionDirective(std::move(src));
+	src = applyRewrites(std::move(src), sharedRewrites());
+	src = applyRewrites(std::move(src), stageRewrites);
+	return preamble + src;
 }
 
 } // anonymous namespace
@@ -160,6 +278,9 @@ void MainWin::loadShader() {
 	if (!user_shader) {
 		vtx = composeShader(defaultVertexShaderBody());
 		frg = composeShader(defaultFragmentShaderBody());
+	} else if (sourceNeedsLegacyShim(vtx) || sourceNeedsLegacyShim(frg)) {
+		vtx = shimLegacyShader(std::move(vtx), vertexRewrites(),   vertexShimPreamble());
+		frg = shimLegacyShader(std::move(frg), fragmentRewrites(), fragmentShimPreamble());
 	}
 
 	prg.removeAllShaders();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,18 +105,25 @@ int main(int ac,char** av) {
 #endif
 	printf("Using Qt ver %s\n",qVersion());
 
-#ifdef __linux__
-// for wayland (activateWindow problem)
-	if (!strcmp(qgetenv("XDG_SESSION_TYPE"), "wayland")) {
-		qunsetenv("XDG_SESSION_TYPE");
-		qEnvironmentVariable("QT_QPA_PLATFORM", "wayland");
+#if (QT_VERSION >= QT_VERSION_CHECK(5,6,0)) && (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
+#ifdef USEOPENGL
+	// NVIDIA+Wayland defaults to a GL ES context, which makes paintEvent's fixed-function calls no-op.
+	{
+		QSurfaceFormat fmt;
+		fmt.setRenderableType(QSurfaceFormat::OpenGL);
+		fmt.setVersion(2, 1);
+		fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
+		fmt.setDepthBufferSize(24);
+		fmt.setStencilBufferSize(8);
+		fmt.setSwapInterval(0);
+		QSurfaceFormat::setDefaultFormat(fmt);
 	}
 #endif
-// this works since Qt5.6 (must be set before QCoreApplication is created). Set by default in Qt6
-	#if (QT_VERSION >= QT_VERSION_CHECK(5,6,0)) && (QT_VERSION < QT_VERSION_CHECK(6,0,0))
-		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-		QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-	#endif
+
 	xApp app(ac,av,true);
 
 #ifdef _WIN32


### PR DESCRIPTION
This fixes Wayland issues (black/empty window) on nVidia and possibly some other setups and some other GL issues.
This code should work everywhere (Linux, Windows, macos, rPI etc.). Tested on Linux hidpi.
Also auto-patches legacy GL shaders (tested with 14 old-style tvline, grill, tridot variants).
Also fixes hidpi scaling on OpenGL. (wayland and X11 and whatever)