### PR TITLE
opengl: Clean up properly

### DIFF
--- a/src/emulwin.cpp
+++ b/src/emulwin.cpp
@@ -235,10 +235,9 @@ MainWin::MainWin() {
 
 MainWin::~MainWin() {
 #if defined(USEOPENGL) && !BLOCKGL
+	cleanupGL();
 	delete(vtx_shd);
 	delete(frg_shd);
-//	for(int i = 0; i < 4; i++)
-//		deleteTexture(texids[i]);
 #endif
 }
 

--- a/src/emulwin.h
+++ b/src/emulwin.h
@@ -233,6 +233,7 @@ typedef struct {
 		void initializeGL();
 		void resizeGL(int,int);
 		void paintGL();
+		void cleanupGL();
 #if ISLEGACYGL
 		QGLContext* cont;
 		QGLShaderProgram prg;

--- a/src/emw_opengl.cpp
+++ b/src/emw_opengl.cpp
@@ -228,6 +228,18 @@ void MainWin::initializeGL() {
 	qDebug() << "end:" << __FUNCTION__;
 }
 
+void MainWin::cleanupGL() {
+#if !ISLEGACYGL
+	if (!vao.isCreated() && !vbo.isCreated()) return;
+	makeCurrent();
+	if (vao.isCreated()) vao.destroy();
+	if (vbo.isCreated()) vbo.destroy();
+	prg.removeAllShaders();
+	glDeleteTextures(4, texids);
+	doneCurrent();
+#endif
+}
+
 void MainWin::resizeGL(int w, int h) {
 	const qreal r = widgetDpr(this);
 	const int vw = int(w * r + 0.5);


### PR DESCRIPTION
Although lack of this code produces only a warning (driver reclaims resources on process exit anyway), let's do this properly as lack of proper cleanup might cause other problems.